### PR TITLE
neovim: update cursorline autocmd

### DIFF
--- a/nvim/lua/user/autocmd.lua
+++ b/nvim/lua/user/autocmd.lua
@@ -10,7 +10,7 @@ vim.api.nvim_create_autocmd({ 'VimEnter', 'WinEnter', 'BufWinEnter' }, {
     vim.opt_local.cursorline = true
   end,
 })
-vim.api.nvim_create_autocmd('VimLeave', {
+vim.api.nvim_create_autocmd({ 'VimLeave', 'WinLeave', 'BufWinLeave' }, {
   group = 'user_toggle_cursorline',
   desc = 'disable cursorline on lost focus',
   pattern = '*',


### PR DESCRIPTION
Hey Georgi, I just wanted to say thanks for sharing your nvim dotfiles, they were a treasure trove of interesting tweaks!

Since there's no `Issue` or `Discussions` panel in this repo, I thought I'd file a PR. I'm pretty sure that `VimLeave` was meant to be `WinLeave`. You don't have to merge this, just pointing it out.